### PR TITLE
Scheme-less URL for Gravatar

### DIFF
--- a/_includes/default.html
+++ b/_includes/default.html
@@ -59,7 +59,7 @@
 			</a>
 			{% endif %}
 			<a class="navbar-brand" href="{{ site.BASE_PATH }}/">
-				<img src="http://www.gravatar.com/avatar/{{site.author.email_md5}}?s=35" class="img-circle" />
+				<img src="//www.gravatar.com/avatar/{{site.author.email_md5}}?s=35" class="img-circle" />
 				{{ site.title }}
 			</a>
 		</div>


### PR DESCRIPTION
Updated the URL for Gravatar to scheme-less so it works over SSL.
